### PR TITLE
fix: add Safe functions to constants

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -29,6 +29,7 @@ archives:
       {{- if eq .Arch "amd64" }}amd64
       {{- else if eq .Arch "arm64" }}arm64
       {{- else }}{{ .Arch }}{{ end }}
+    mode: 0755
 
 checksum:
   name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'

--- a/core/constants.go
+++ b/core/constants.go
@@ -144,6 +144,8 @@ var KnownABIJSON = []string{
 	`[{"inputs":[{"name":"targets","type":"address[]"},{"name":"values","type":"uint256[]"},{"name":"calldatas","type":"bytes[]"},{"name":"description","type":"string"},{"name":"proposalType","type":"uint8"}],"name":"propose","type":"function"}]`,
 	`[{"inputs":[{"name":"opChainConfigs","type":"tuple[]","components":[{"name":"systemConfigProxy","type":"address"},{"name":"proxyAdmin","type":"address"},{"name":"absolutePrestate","type":"bytes32"}]}],"name":"upgrade","type":"function"}]`,
 	`[{"inputs":[{"components":[{"name":"schema","type":"bytes32"},{"components":[{"name":"recipient","type":"address"},{"name":"expirationTime","type":"uint64"},{"name":"revocable","type":"bool"},{"name":"refUID","type":"bytes32"},{"name":"data","type":"bytes"},{"name":"value","type":"uint256"}],"name":"data","type":"tuple"}],"name":"request","type":"tuple"}],"name":"attest","type":"function"}]`,
+	`[{"inputs":[{"name":"owner","type":"address"},{"name":"threshold","type":"uint256"}],"name":"addOwnerWithThreshold","type":"function"}]`,
+	`[{"inputs":[{"name":"prevOwner","type":"address"},{"name":"owner","type":"address"},{"name":"threshold","type":"uint256"}],"name":"removeOwner","type":"function"}]`,
 }
 
 // Initialize known functions


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Adds primary safe manipulation functions as constants.