### PR TITLE
fix: correct safe version for nested legacy safes

### DIFF
--- a/core/verify.go
+++ b/core/verify.go
@@ -81,6 +81,7 @@ func VerifyTransaction(tx SafeTransaction, options VerifyOptions) (*Verification
 		tx.Operation = tx.Nested.Operation
 		tx.Value = big.NewInt(0)
 		tx.Data = tx.Nested.Data
+		tx.SafeVersion = tx.Nested.SafeVersion
 	}
 
 	// Verify the main transaction


### PR DESCRIPTION
Fixes a bug where if a nested safe was being used to sign on a parent safe and the nested safe was a legacy safe, the wrong domain hash would be printed.
