### PR TITLE
feat: add OPCM V6/V7 addresses and upgrade function signatures

### DIFF
--- a/core/constants.go
+++ b/core/constants.go
@@ -40,10 +40,14 @@ const (
 	OPCMv300Mainnet          = "0x3A1f523a4bc09cd344A2745a108Bb0398288094F"
 	OPCMv410Mainnet          = "0x8123739C1368C2DEDc8C564255bc417FEEeBFF9D"
 	OPCMv500Mainnet          = "0xFa1Ef97fb02B0dA2Ee2346b8e310907ab5519449"
+	OPCMv600Mainnet          = "0x50F47B43c24F40B92C873Fa0704D4207586D0C9f"
+	OPCMv700Mainnet          = "0x9Ce712Ff84E02659846dc6450BB9b7642fE8bE5D"
 	OPCMv220Sepolia          = "0x6b6f9129efb1b7a48f84e3b787333d1dca02ee34"
 	OPCMv300Sepolia          = "0xfBceeD4DE885645fBdED164910E10F52fEBFAB35"
 	OPCMv410Sepolia          = "0x3bb6437aba031afbf9cb3538fa064161e2bf2d78"
 	OPCMv500Sepolia          = "0xC69e4c24Db479191676611a25D977203c3BDca62"
+	OPCMv600Sepolia          = "0xF0a2e224519E876979eA6B2cd15eF5CC3d6703bd"
+	OPCMv700Sepolia          = "0x44e197058fb98Fb3618453b3D90CDEf6f5Db8297"
 	CCTPv2                   = "0x28b5a0e9C621a5BadaA536219b3a228C8168cf5d"
 	OPL1StandardBridge       = "0x99C9fc46f92E8a1c0deC1b1747d010903E884bE1"
 	OPL2StandardBridge       = "0x4200000000000000000000000000000000000010"
@@ -109,6 +113,8 @@ var KnownContracts = map[uint64]map[string]ContractInfo{
 		strings.ToLower(OPCMv300Mainnet):          {Name: "OPContractsManager V3.0.0", Decimals: 0},
 		strings.ToLower(OPCMv410Mainnet):          {Name: "OPContractsManager V4.1.0", Decimals: 0},
 		strings.ToLower(OPCMv500Mainnet):          {Name: "OPContractsManager V5.0.0", Decimals: 0},
+		strings.ToLower(OPCMv600Mainnet):          {Name: "OPContractsManager V6.0.0", Decimals: 0},
+		strings.ToLower(OPCMv700Mainnet):          {Name: "OPContractsManager V7.0.0", Decimals: 0},
 		strings.ToLower(CCTPv2):                   {Name: "CCTP V2", Decimals: 0},
 		strings.ToLower(OPL1StandardBridge):       {Name: "OP L1StandardBridge", Decimals: 0},
 		strings.ToLower(SaferSafes):               {Name: "SaferSafes", Decimals: 0},
@@ -146,6 +152,8 @@ var KnownContracts = map[uint64]map[string]ContractInfo{
 		strings.ToLower(OPCMv300Sepolia):        {Name: "OPContractsManager V3.0.0", Decimals: 0},
 		strings.ToLower(OPCMv410Sepolia):        {Name: "OPContractsManager V4.1.0", Decimals: 0},
 		strings.ToLower(OPCMv500Sepolia):        {Name: "OPContractsManager V5.0.0", Decimals: 0},
+		strings.ToLower(OPCMv600Sepolia):        {Name: "OPContractsManager V6.0.0", Decimals: 0},
+		strings.ToLower(OPCMv700Sepolia):        {Name: "OPContractsManager V7.0.0", Decimals: 0},
 		strings.ToLower(SaferSafes):             {Name: "SaferSafes", Decimals: 0},
 	},
 	OPSepoliaChainID: {
@@ -209,8 +217,15 @@ var KnownABIJSON = []string{
 	`[{"inputs":[{"name":"amount","type":"uint256"},{"name":"destinationDomain","type":"uint32"},{"name":"mintRecipient","type":"bytes32"},{"name":"burnToken","type":"address"},{"name":"destinationCaller","type":"bytes32"},{"name":"maxFee","type":"uint256"},{"name":"minFinalityThreshold","type":"uint32"}],"name":"depositForBurn","outputs":[],"stateMutability":"nonpayable","type":"function"}]`,
 	`[{"inputs":[{"internalType":"address","name":"to","type":"address"},{"internalType":"uint32","name":"minGasLimit","type":"uint32"},{"internalType":"bytes","name":"extraData","type":"bytes"}],"name":"bridgeETHTo","outputs":[],"stateMutability":"payable","type":"function"}]`,
 	`[{"inputs":[{"name":"superchainConfig","type":"address"},{"name":"superchainProxyAdmin","type":"address"}],"name":"upgradeSuperchainConfig","outputs":[],"stateMutability":"nonpayable","type":"function"}]`,
-	`[{"inputs":[{"internalType": "bytes32","name": "safeTxHash","type": "bytes32"}],"name": "signCancellation","outputs": [],"stateMutability": "nonpayable","type": "function"}]`, // signCancellation
-	`[{"inputs":[{"internalType": "contract Safe","name": "safe","type": "address"}],"name": "challenge","outputs": [],"stateMutability": "nonpayable","type": "function"}]`,        // challenge
+	`[{"inputs":[{"name":"_inp","type":"tuple","components":[{"name":"systemConfig","type":"address"},{"name":"disputeGameConfigs","type":"tuple[]","components":[{"name":"enabled","type":"bool"},{"name":"initBond","type":"uint256"},{"name":"gameType","type":"uint32"},{"name":"gameArgs","type":"bytes"}]},{"name":"extraInstructions","type":"tuple[]","components":[{"name":"key","type":"string"},{"name":"data","type":"bytes"}]}]}],"name":"upgrade","outputs":[],"stateMutability":"nonpayable","type":"function"}]`,                                                                                                                                                                    // OPCM V2 upgrade
+	`[{"inputs":[{"name":"_inp","type":"tuple","components":[{"name":"superchainConfig","type":"address"},{"name":"extraInstructions","type":"tuple[]","components":[{"name":"key","type":"string"},{"name":"data","type":"bytes"}]}]}],"name":"upgradeSuperchain","outputs":[],"stateMutability":"nonpayable","type":"function"}]`,                                                                                                                                                                                                                                                                                                                                                                 // OPCM V2 upgradeSuperchain
+	`[{"inputs":[{"name":"_input","type":"tuple","components":[{"name":"chainSystemConfigs","type":"address[]"},{"name":"disputeGameConfigs","type":"tuple[]","components":[{"name":"enabled","type":"bool"},{"name":"initBond","type":"uint256"},{"name":"gameType","type":"uint32"},{"name":"gameArgs","type":"bytes"}]},{"name":"startingAnchorRoot","type":"tuple","components":[{"name":"root","type":"bytes32"},{"name":"l2SequenceNumber","type":"uint256"}]},{"name":"startingRespectedGameType","type":"uint32"}]}],"name":"migrate","outputs":[],"stateMutability":"nonpayable","type":"function"}]`,                                                                                      // OPCM V2 migrate
+	`[{"inputs":[{"name":"_opChainConfigs","type":"tuple[]","components":[{"name":"systemConfigProxy","type":"address"},{"name":"cannonPrestate","type":"bytes32"},{"name":"cannonKonaPrestate","type":"bytes32"}]}],"name":"upgrade","outputs":[],"stateMutability":"nonpayable","type":"function"}]`,                                                                                                                                                                                                                                                                                                                                                                                              // OPCM V6 upgrade
+	`[{"inputs":[{"name":"_prestateUpdateInputs","type":"tuple[]","components":[{"name":"systemConfigProxy","type":"address"},{"name":"cannonPrestate","type":"bytes32"},{"name":"cannonKonaPrestate","type":"bytes32"}]}],"name":"updatePrestate","outputs":[],"stateMutability":"nonpayable","type":"function"}]`,                                                                                                                                                                                                                                                                                                                                                                                 // OPCM V6 updatePrestate
+	`[{"inputs":[{"name":"_gameConfigs","type":"tuple[]","components":[{"name":"saltMixer","type":"string"},{"name":"systemConfig","type":"address"},{"name":"delayedWETH","type":"address"},{"name":"disputeGameType","type":"uint32"},{"name":"disputeAbsolutePrestate","type":"bytes32"},{"name":"disputeMaxGameDepth","type":"uint256"},{"name":"disputeSplitDepth","type":"uint256"},{"name":"disputeClockExtension","type":"uint64"},{"name":"disputeMaxClockDuration","type":"uint64"},{"name":"initialBond","type":"uint256"},{"name":"vm","type":"address"},{"name":"permissioned","type":"bool"}]}],"name":"addGameType","outputs":[],"stateMutability":"nonpayable","type":"function"}]`, // OPCM V6 addGameType
+	`[{"inputs":[{"name":"_input","type":"tuple","components":[{"name":"usePermissionlessGame","type":"bool"},{"name":"startingAnchorRoot","type":"tuple","components":[{"name":"root","type":"bytes32"},{"name":"l2SequenceNumber","type":"uint256"}]},{"name":"gameParameters","type":"tuple","components":[{"name":"proposer","type":"address"},{"name":"challenger","type":"address"},{"name":"maxGameDepth","type":"uint256"},{"name":"splitDepth","type":"uint256"},{"name":"initBond","type":"uint256"},{"name":"clockExtension","type":"uint64"},{"name":"maxClockDuration","type":"uint64"}]},{"name":"opChainConfigs","type":"tuple[]","components":[{"name":"systemConfigProxy","type":"address"},{"name":"cannonPrestate","type":"bytes32"},{"name":"cannonKonaPrestate","type":"bytes32"}]}]}],"name":"migrate","outputs":[],"stateMutability":"nonpayable","type":"function"}]`, // OPCM V6 migrate
+	`[{"inputs":[{"internalType": "bytes32","name": "safeTxHash","type": "bytes32"}],"name": "signCancellation","outputs": [],"stateMutability": "nonpayable","type": "function"}]`,          // signCancellation
+	`[{"inputs":[{"internalType": "contract Safe","name": "safe","type": "address"}],"name": "challenge","outputs": [],"stateMutability": "nonpayable","type": "function"}]`,                 // challenge
 	`[{"inputs":[],"name": "respond","outputs": [],"stateMutability": "nonpayable","type": "function"}]`,                                                                                     // respond
 	`[{"inputs":[{"internalType": "contract Safe","name": "safe","type": "address"}],"name": "changeOwnershipToFallback","outputs": [],"stateMutability": "nonpayable","type": "function"}]`, // changeOwnershipToFallback
 	`[{"inputs":[{"name":"handler","type":"address"}],"name":"setFallbackHandler","outputs":[],"stateMutability":"nonpayable","type":"function"}]`,                                           // setFallbackHandler


### PR DESCRIPTION
Adds the OPCM V6.0.0 and V7.0.0 contracts and their upgrade entry-point functions so signers verifying these upgrade txns see known contract names and decoded calldata.

**Addresses** (mainnet + sepolia), registered in `KnownContracts`:
- V6.0.0: `0x50F47B43c24F40B92C873Fa0704D4207586D0C9f` / `0xF0a2e224519E876979eA6B2cd15eF5CC3d6703bd`
- V7.0.0: `0x9Ce712Ff84E02659846dc6450BB9b7642fE8bE5D` / `0x44e197058fb98Fb3618453b3D90CDEf6f5Db8297`

**Functions** added to `KnownABIJSON` (named fields for readable decoding):
- V7: `upgrade` (0x8a847e2e), `upgradeSuperchain` (0x86fe1c66), `migrate` (0xba55287c)
- V6: `upgrade` (0xcbeda5a7), `updatePrestate` (0xb23cc044), `addGameType` (0x604aa628), `migrate` (0x58084273)

V6's `upgrade`/`updatePrestate` use a different `OpChainConfig` shape (`cannonPrestate` + `cannonKonaPrestate`) than the existing entries; selectors don't collide, so both decode correctly. All selectors verified against the contract interfaces via `cast sig` and a runtime check of `KnownFunctions`.